### PR TITLE
Update guildford_gov_uk.py to fix type issues

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/guildford_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/guildford_gov_uk.py
@@ -25,7 +25,7 @@ API_URL = "https://my.guildford.gov.uk/customers/s/sfsites/aura?r=10&other.BinSc
 
 class Source:
     def __init__(self, uprn):
-        self._uprn = uprn
+        self._uprn = str(uprn)
 
     def fetch(self):
         # The API uses this framework cookie, which seems to last 2 weeks.


### PR DESCRIPTION
Line 34 caused an issue with type errors, so I've cast it to a string when reading it in initially:

`fetch failed for source Guildford Borough Council: Traceback (most recent call last): File "/config/custom_components/waste_collection_schedule/waste_collection_schedule/source_shell.py", line 134, in fetch entries = self._source.fetch() ^^^^^^^^^^^^^^^^^^^^ File "/config/custom_components/waste_collection_schedule/waste_collection_schedule/source/guildford_gov_uk.py", line 34, in fetch "message=%7B%22actions%22%3A%5B%7B%22id%22%3A%22291%3Ba%22%2C%22descriptor%22%3A%22apex%3A%2F%2FBinScheduleDisplayCmpController%2FACTION%24GetBinSchedules%22%2C%22callingDescriptor%22%3A%22markup%3A%2F%2Fc%3ABinScheduleDisplay%22%2C%22params%22%3A%7B%22database%22%3A%22domestic%22%2C%22UPRN%22%3A%22" TypeError: can only concatenate str (not "int") to str`

I believe I've followed the contributing guidelines. This is my first PR and Python experience so forgive me if I've missed anything.